### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-description.yml
+++ b/.github/workflows/docker-description.yml
@@ -1,4 +1,6 @@
 name: 'Docker Publish Description'
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/BJReplay/caddy-crowdsec-cf-dns/security/code-scanning/4](https://github.com/BJReplay/caddy-crowdsec-cf-dns/security/code-scanning/4)

To fix the problem, add an explicit `permissions` block to the workflow—either at the workflow level (near the top, so it applies to all jobs) or at the job level under the relevant job (in this case, `sync:`). The minimal baseline is to set `contents: read`, which is enough for most jobs that only need access to repo contents, and not broader write access. To implement the fix, insert the following under the workflow name and prior to the `on:` block (recommended), or under the job's config block as appropriate. No additional imports or methods are needed; just update the YAML config as shown.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
